### PR TITLE
Fourth Hydrophone Support with Conditional Switching

### DIFF
--- a/Assets/Prefabs/Diana.prefab
+++ b/Assets/Prefabs/Diana.prefab
@@ -9844,6 +9844,37 @@ MeshFilter:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1895543544804091106}
   m_Mesh: {fileID: -5368255686313445931, guid: e887983eeac3f204e95bd0e56bf28deb, type: 3}
+--- !u!1 &2147572688685011025
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 480369389584627130}
+  m_Layer: 7
+  m_Name: H4
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &480369389584627130
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2147572688685011025}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: -0.3, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 142454021354145122}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &2396982645971625551
 GameObject:
   m_ObjectHideFlags: 0
@@ -29943,6 +29974,7 @@ Transform:
   - {fileID: 4593424934240793374}
   - {fileID: 7185839655269147826}
   - {fileID: 1702395658486560678}
+  - {fileID: 480369389584627130}
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: -90, z: 0}
 --- !u!65 &5558434845062824359
@@ -30123,6 +30155,7 @@ MonoBehaviour:
   hydrophone1: {fileID: 0}
   hydrophone2: {fileID: 0}
   hydrophone3: {fileID: 0}
+  hydrophone4: {fileID: 0}
   pinger1: {fileID: 0}
   pinger2: {fileID: 0}
   pinger3: {fileID: 0}

--- a/Assets/Scenes/SquarePool.unity
+++ b/Assets/Scenes/SquarePool.unity
@@ -402,6 +402,12 @@ Transform:
   - {fileID: 903474673884779288}
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!4 &393137689 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4593424934240793374, guid: 1b569bfd0ceba054590bd50d26375651,
+    type: 3}
+  m_PrefabInstance: {fileID: 8685048131078817679}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1 &731648943
 GameObject:
   m_ObjectHideFlags: 0
@@ -510,6 +516,12 @@ Transform:
   m_CorrespondingSourceObject: {fileID: 357466907183608939, guid: aa61c4e32bb17c741850c8493a01975c,
     type: 3}
   m_PrefabInstance: {fileID: 755665431}
+  m_PrefabAsset: {fileID: 0}
+--- !u!4 &760109512 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 480369389584627130, guid: 1b569bfd0ceba054590bd50d26375651,
+    type: 3}
+  m_PrefabInstance: {fileID: 8685048131078817679}
   m_PrefabAsset: {fileID: 0}
 --- !u!1001 &813260827
 PrefabInstance:
@@ -1053,6 +1065,12 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 1830194917}
   m_PrefabAsset: {fileID: 0}
+--- !u!4 &1907267124 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 7185839655269147826, guid: 1b569bfd0ceba054590bd50d26375651,
+    type: 3}
+  m_PrefabInstance: {fileID: 8685048131078817679}
+  m_PrefabAsset: {fileID: 0}
 --- !u!4 &2005052683 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 1487725964637141184, guid: 43a06d251454db744b1961d17085d98a,
@@ -1163,6 +1181,12 @@ Transform:
   m_CorrespondingSourceObject: {fileID: 357466907183608939, guid: aa61c4e32bb17c741850c8493a01975c,
     type: 3}
   m_PrefabInstance: {fileID: 2041468934}
+  m_PrefabAsset: {fileID: 0}
+--- !u!4 &2075251490 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 1702395658486560678, guid: 1b569bfd0ceba054590bd50d26375651,
+    type: 3}
+  m_PrefabInstance: {fileID: 8685048131078817679}
   m_PrefabAsset: {fileID: 0}
 --- !u!1001 &550464106571170563
 PrefabInstance:
@@ -2089,6 +2113,36 @@ PrefabInstance:
       propertyPath: ROSClock
       value: 
       objectReference: {fileID: 8624929}
+    - target: {fileID: 2147572688685011025, guid: 1b569bfd0ceba054590bd50d26375651,
+        type: 3}
+      propertyPath: m_Name
+      value: HZ
+      objectReference: {fileID: 0}
+    - target: {fileID: 2396982645971625551, guid: 1b569bfd0ceba054590bd50d26375651,
+        type: 3}
+      propertyPath: m_Name
+      value: HX
+      objectReference: {fileID: 0}
+    - target: {fileID: 4394602334487593476, guid: 1b569bfd0ceba054590bd50d26375651,
+        type: 3}
+      propertyPath: m_Name
+      value: HY
+      objectReference: {fileID: 0}
+    - target: {fileID: 4593424934240793374, guid: 1b569bfd0ceba054590bd50d26375651,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0.1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4593424934240793374, guid: 1b569bfd0ceba054590bd50d26375651,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5497699506469662933, guid: 1b569bfd0ceba054590bd50d26375651,
+        type: 3}
+      propertyPath: Diana
+      value: 
+      objectReference: {fileID: 6207282852912111775}
     - target: {fileID: 5497699506469662933, guid: 1b569bfd0ceba054590bd50d26375651,
         type: 3}
       propertyPath: pinger1
@@ -2124,16 +2178,56 @@ PrefabInstance:
       propertyPath: hydrophone3
       value: 
       objectReference: {fileID: 2005052683}
+    - target: {fileID: 5497699506469662933, guid: 1b569bfd0ceba054590bd50d26375651,
+        type: 3}
+      propertyPath: hydrophone4
+      value: 
+      objectReference: {fileID: 760109512}
+    - target: {fileID: 5497699506469662933, guid: 1b569bfd0ceba054590bd50d26375651,
+        type: 3}
+      propertyPath: hydrophoneO
+      value: 
+      objectReference: {fileID: 2075251490}
+    - target: {fileID: 5497699506469662933, guid: 1b569bfd0ceba054590bd50d26375651,
+        type: 3}
+      propertyPath: hydrophoneX
+      value: 
+      objectReference: {fileID: 393137689}
+    - target: {fileID: 5497699506469662933, guid: 1b569bfd0ceba054590bd50d26375651,
+        type: 3}
+      propertyPath: hydrophoneY
+      value: 
+      objectReference: {fileID: 1907267124}
+    - target: {fileID: 5497699506469662933, guid: 1b569bfd0ceba054590bd50d26375651,
+        type: 3}
+      propertyPath: hydrophoneZ
+      value: 
+      objectReference: {fileID: 760109512}
     - target: {fileID: 6642039138362327368, guid: 1b569bfd0ceba054590bd50d26375651,
         type: 3}
       propertyPath: m_Name
       value: Diana
+      objectReference: {fileID: 0}
+    - target: {fileID: 7185839655269147826, guid: 1b569bfd0ceba054590bd50d26375651,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7185839655269147826, guid: 1b569bfd0ceba054590bd50d26375651,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0.1
       objectReference: {fileID: 0}
     - target: {fileID: 8399238135166730803, guid: 1b569bfd0ceba054590bd50d26375651,
         type: 3}
       propertyPath: ROSClock
       value: 
       objectReference: {fileID: 8624929}
+    - target: {fileID: 8863598140929573514, guid: 1b569bfd0ceba054590bd50d26375651,
+        type: 3}
+      propertyPath: m_Name
+      value: HO
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
     m_AddedGameObjects: []

--- a/Assets/Scenes/SquarePool.unity
+++ b/Assets/Scenes/SquarePool.unity
@@ -2202,7 +2202,7 @@ PrefabInstance:
         type: 3}
       propertyPath: hydrophoneZ
       value: 
-      objectReference: {fileID: 760109512}
+      objectReference: {fileID: 0}
     - target: {fileID: 6642039138362327368, guid: 1b569bfd0ceba054590bd50d26375651,
         type: 3}
       propertyPath: m_Name

--- a/Assets/Scripts/PingerTimeDifference.cs
+++ b/Assets/Scripts/PingerTimeDifference.cs
@@ -13,38 +13,39 @@ public class PingerTimeDifference : MonoBehaviour {
     private PingerTimeDifferenceMsg timeDiffMsg = new PingerTimeDifferenceMsg();
     private double speedOfSound = 1480.0;
 
-    public Transform hydrophone1;
-    public Transform hydrophone2;
-    public Transform hydrophone3;
-    public Transform hydrophone4;
+    public Transform hydrophoneO;
+    public Transform hydrophoneX;
+    public Transform hydrophoneY;
+    public Transform hydrophoneZ;
     public Transform pinger1;
     public Transform pinger2;
     public Transform pinger3;
     public Transform pinger4;
     
+
     Vector3 pinger1Bearing;
     Vector3 pinger2Bearing;
     Vector3 pinger3Bearing;
     Vector3 pinger4Bearing;
 
-    double[] d1 = new double[4];
-    double[] d2 = new double[4];
-    double[] d3 = new double[4];
-    double[] d4 = new double[4];    // for fourth hydrophone
+    double[] dO = new double[4];
+    double[] dX = new double[4];
+    double[] dY = new double[4];
+    double[] dZ = new double[4];    // for fourth hydrophone
 
-    double[] time1 = new double[4];
-    double[] time2 = new double[4];
-    double[] time3 = new double[4];
-    double[] time4 = new double[4]; 
-    double[] time2Diff = new double[4];
-    double[] time3Diff = new double[4];
-    double[] time4Diff = new double[4]; 
+    double[] timeO = new double[4];
+    double[] timeX = new double[4];
+    double[] timeY = new double[4];
+    double[] timeZ = new double[4]; 
+    double[] timeXDiff = new double[4];
+    double[] timeYDiff = new double[4];
+    double[] timeZDiff = new double[4]; 
 
     void Start() {
-        hydrophone1.position = transform.position + Vector3.up * -0.5f;
-        hydrophone2.position = hydrophone1.position + Vector3.forward * 0.1f;
-        hydrophone3.position = hydrophone1.position + Vector3.right * -0.1f;
-        hydrophone4.position = hydrophone1.position + Vector3.up * -0.1f;   // Position unsure, change if incorrect
+        // hydrophoneO.position = transform.position +  Vector3.up * -0.5f;
+        // hydrophoneX.position = hydrophoneO.position + Vector3.forward * 0.1f;
+        // hydrophoneY.position = hydrophoneO.position + Vector3.right * -0.1f;
+        // hydrophoneZ.position =  hydrophoneO.position + Vector3.up * -0.1f;   // Position unsure, change if incorrect
 
         roscon = ROSConnection.GetOrCreateInstance();
         roscon.RegisterPublisher<PingerTimeDifferenceMsg>(pingerTimeDifferenceTopicName); 
@@ -57,70 +58,70 @@ public class PingerTimeDifference : MonoBehaviour {
         timeDiffMsg.is_pinger4_active = true;
         
         // Pinger 1
-        d1[0] = Vector3.Distance(hydrophone1.position, pinger1.position);
-        d2[0] = Vector3.Distance(hydrophone2.position, pinger1.position);
-        d3[0] = Vector3.Distance(hydrophone3.position, pinger1.position);
-        d4[0] = Vector3.Distance(hydrophone4.position, pinger1.position);
+        dO[0] = Vector3.Distance(hydrophoneO.position, pinger1.position);
+        dX[0] = Vector3.Distance(hydrophoneX.position, pinger1.position);
+        dY[0] = Vector3.Distance(hydrophoneY.position, pinger1.position);
+        dZ[0] = Vector3.Distance(hydrophoneZ.position, pinger1.position);
 
-        time1[0] = d1[0] / speedOfSound;
-        time2[0] = d2[0] / speedOfSound;
-        time3[0] = d3[0] / speedOfSound;
-        time4[0] = d4[0] / speedOfSound;
+        timeO[0] = dO[0] / speedOfSound;
+        timeX[0] = dX[0] / speedOfSound;
+        timeY[0] = dY[0] / speedOfSound;
+        timeZ[0] = dZ[0] / speedOfSound;
 
-        time2Diff[0] = time2[0] - time1[0];
-        time3Diff[0] = time3[0] - time1[0];
-        time4Diff[0] = time4[0] - time1[0];
+        timeXDiff[0] = timeO[0] - timeX[0];
+        timeYDiff[0] = timeO[0] - timeY[0];
+        timeZDiff[0] = timeO[0] - timeZ[0];
 
         // Pinger 2
-        d1[1] = Vector3.Distance(hydrophone1.position, pinger2.position);
-        d2[1] = Vector3.Distance(hydrophone2.position, pinger2.position);
-        d3[1] = Vector3.Distance(hydrophone3.position, pinger2.position);
-        d4[1] = Vector3.Distance(hydrophone4.position, pinger2.position);
+        dO[1] = Vector3.Distance(hydrophoneO.position, pinger2.position);
+        dX[1] = Vector3.Distance(hydrophoneX.position, pinger2.position);
+        dY[1] = Vector3.Distance(hydrophoneY.position, pinger2.position);
+        dZ[1] = Vector3.Distance(hydrophoneZ.position, pinger2.position);
 
-        time1[1] = d1[1] / speedOfSound;
-        time2[1] = d2[1] / speedOfSound;
-        time3[1] = d3[1] / speedOfSound;
-        time4[1] = d4[1] / speedOfSound;
+        timeO[1] = dO[1] / speedOfSound;
+        timeX[1] = dX[1] / speedOfSound;
+        timeY[1] = dY[1] / speedOfSound;
+        timeZ[1] = dZ[1] / speedOfSound;
 
-        time2Diff[1] = time2[1] - time1[1];
-        time3Diff[1] = time3[1] - time1[1];
-        time4Diff[1] = time4[1] - time1[1];
+        timeXDiff[1] = timeO[1] - timeX[1];
+        timeYDiff[1] = timeO[1] - timeY[1];
+        timeZDiff[1] = timeO[1] - timeZ[1];
 
         // Pinger 3
-        d1[2] = Vector3.Distance(hydrophone1.position, pinger3.position);
-        d2[2] = Vector3.Distance(hydrophone2.position, pinger3.position);
-        d3[2] = Vector3.Distance(hydrophone3.position, pinger3.position);
-        d4[2] = Vector3.Distance(hydrophone4.position, pinger3.position);
+        dO[2] = Vector3.Distance(hydrophoneO.position, pinger3.position);
+        dX[2] = Vector3.Distance(hydrophoneX.position, pinger3.position);
+        dY[2] = Vector3.Distance(hydrophoneY.position, pinger3.position);
+        dZ[2] = Vector3.Distance(hydrophoneZ.position, pinger3.position);
 
-        time1[2] = d1[2] / speedOfSound;
-        time2[2] = d2[2] / speedOfSound;
-        time3[2] = d3[2] / speedOfSound;
-        time4[2] = d4[2] / speedOfSound;
+        timeO[2] = dO[2] / speedOfSound;
+        timeX[2] = dX[2] / speedOfSound;
+        timeY[2] = dY[2] / speedOfSound;
+        timeZ[2] = dZ[2] / speedOfSound;
 
-        time2Diff[2] = time2[2] - time1[2];
-        time3Diff[2] = time3[2] - time1[2];
-        time4Diff[2] = time4[2] - time1[2];
+        timeXDiff[2] =  timeO[2] - timeX[2];
+        timeYDiff[2] =  timeO[2] - timeY[2];
+        timeZDiff[2] =  timeO[2] - timeZ[2];
 
         // Pinger 4
-        d1[3] = Vector3.Distance(hydrophone1.position, pinger4.position);
-        d2[3] = Vector3.Distance(hydrophone2.position, pinger4.position);
-        d3[3] = Vector3.Distance(hydrophone3.position, pinger4.position);
-        d4[3] = Vector3.Distance(hydrophone4.position, pinger4.position);
+        dO[3] = Vector3.Distance(hydrophoneO.position, pinger4.position);
+        dX[3] = Vector3.Distance(hydrophoneX.position, pinger4.position);
+        dY[3] = Vector3.Distance(hydrophoneY.position, pinger4.position);
+        dZ[3] = Vector3.Distance(hydrophoneZ.position, pinger4.position);
 
-        time1[3] = d1[3] / speedOfSound;
-        time2[3] = d2[3] / speedOfSound;
-        time3[3] = d3[3] / speedOfSound;
-        time4[3] = d4[3] / speedOfSound;
+        timeO[3] = dO[3] / speedOfSound;
+        timeX[3] = dX[3] / speedOfSound;
+        timeY[3] = dY[3] / speedOfSound;
+        timeZ[3] = dZ[3] / speedOfSound;
 
-        time2Diff[3] = time2[3] - time1[3];
-        time3Diff[3] = time3[3] - time1[3];
-        time4Diff[3] = time4[3] - time1[3];
+        timeXDiff[3] = timeO[3] - timeX[3];
+        timeYDiff[3] = timeO[3] - timeY[3];
+        timeZDiff[3] = timeO[3] - timeZ[3];
         
 
-        timeDiffMsg.dt_pinger1 = new double[3] {time2Diff[0], time3Diff[0], time4Diff[0]};
-        timeDiffMsg.dt_pinger2 = new double[3] {time2Diff[1], time3Diff[1], time4Diff[1]};
-        timeDiffMsg.dt_pinger3 = new double[3] {time2Diff[2], time3Diff[2], time4Diff[2]};
-        timeDiffMsg.dt_pinger4 = new double[3] {time2Diff[3], time3Diff[3], time4Diff[3]};
+        timeDiffMsg.dt_pinger1 = new double[3] {timeXDiff[0], timeYDiff[0], timeZDiff[0]};
+        timeDiffMsg.dt_pinger2 = new double[3] {timeXDiff[1], timeYDiff[1], timeZDiff[1]};
+        timeDiffMsg.dt_pinger3 = new double[3] {timeXDiff[2], timeYDiff[2], timeZDiff[2]};
+        timeDiffMsg.dt_pinger4 = new double[3] {timeXDiff[3], timeYDiff[3], timeZDiff[3]};
 
         roscon.Publish(pingerTimeDifferenceTopicName, timeDiffMsg);
     }

--- a/Assets/Scripts/PingerTimeDifference.cs
+++ b/Assets/Scripts/PingerTimeDifference.cs
@@ -51,7 +51,69 @@ public class PingerTimeDifference : MonoBehaviour {
         roscon.RegisterPublisher<PingerTimeDifferenceMsg>(pingerTimeDifferenceTopicName); 
     }
 
-    void calculateTimeDifference() {
+    void calculateTimeDifference2D() {
+        timeDiffMsg.is_pinger1_active = true;
+        timeDiffMsg.is_pinger2_active = true;
+        timeDiffMsg.is_pinger3_active = true;
+        timeDiffMsg.is_pinger4_active = true;
+        
+        // Pinger 1
+        dO[0] = Vector3.Distance(hydrophoneO.position, pinger1.position);
+        dX[0] = Vector3.Distance(hydrophoneX.position, pinger1.position);
+        dY[0] = Vector3.Distance(hydrophoneY.position, pinger1.position);
+
+        timeO[0] = dO[0] / speedOfSound;
+        timeX[0] = dX[0] / speedOfSound;
+        timeY[0] = dY[0] / speedOfSound;
+
+        timeXDiff[0] = timeO[0] - timeX[0];
+        timeYDiff[0] = timeO[0] - timeY[0];
+
+        // Pinger 2
+        dO[1] = Vector3.Distance(hydrophoneO.position, pinger2.position);
+        dX[1] = Vector3.Distance(hydrophoneX.position, pinger2.position);
+        dY[1] = Vector3.Distance(hydrophoneY.position, pinger2.position);
+
+        timeO[1] = dO[1] / speedOfSound;
+        timeX[1] = dX[1] / speedOfSound;
+        timeY[1] = dY[1] / speedOfSound;
+
+        timeXDiff[1] = timeO[1] - timeX[1];
+        timeYDiff[1] = timeO[1] - timeY[1];
+
+        // Pinger 3
+        dO[2] = Vector3.Distance(hydrophoneO.position, pinger3.position);
+        dX[2] = Vector3.Distance(hydrophoneX.position, pinger3.position);
+        dY[2] = Vector3.Distance(hydrophoneY.position, pinger3.position);
+
+        timeO[2] = dO[2] / speedOfSound;
+        timeX[2] = dX[2] / speedOfSound;
+        timeY[2] = dY[2] / speedOfSound;
+
+        timeXDiff[2] =  timeO[2] - timeX[2];
+        timeYDiff[2] =  timeO[2] - timeY[2];
+
+        // Pinger 4
+        dO[3] = Vector3.Distance(hydrophoneO.position, pinger4.position);
+        dX[3] = Vector3.Distance(hydrophoneX.position, pinger4.position);
+        dY[3] = Vector3.Distance(hydrophoneY.position, pinger4.position);
+
+        timeO[3] = dO[3] / speedOfSound;
+        timeX[3] = dX[3] / speedOfSound;
+        timeY[3] = dY[3] / speedOfSound;
+
+        timeXDiff[3] = timeO[3] - timeX[3];
+        timeYDiff[3] = timeO[3] - timeY[3];
+        
+        timeDiffMsg.dt_pinger1 = new double[2] {timeXDiff[0], timeYDiff[0]};
+        timeDiffMsg.dt_pinger2 = new double[2] {timeXDiff[1], timeYDiff[1]};
+        timeDiffMsg.dt_pinger3 = new double[2] {timeXDiff[2], timeYDiff[2]};
+        timeDiffMsg.dt_pinger4 = new double[2] {timeXDiff[3], timeYDiff[3]};
+
+        roscon.Publish(pingerTimeDifferenceTopicName, timeDiffMsg);
+    }
+
+    void calculateTimeDifference3D() {
         timeDiffMsg.is_pinger1_active = true;
         timeDiffMsg.is_pinger2_active = true;
         timeDiffMsg.is_pinger3_active = true;
@@ -127,6 +189,9 @@ public class PingerTimeDifference : MonoBehaviour {
     }
 
     void Update() {
-        calculateTimeDifference();
+        if (hydrophoneZ == null) {
+            calculateTimeDifference2D();
+        }
+        calculateTimeDifference3D();
     }
 }

--- a/Assets/Scripts/PingerTimeDifference.cs
+++ b/Assets/Scripts/PingerTimeDifference.cs
@@ -44,7 +44,7 @@ public class PingerTimeDifference : MonoBehaviour {
         hydrophone1.position = transform.position + Vector3.up * -0.5f;
         hydrophone2.position = hydrophone1.position + Vector3.forward * 0.1f;
         hydrophone3.position = hydrophone1.position + Vector3.right * -0.1f;
-        hydrophone4.position = hydrophone1.position + Vector3.up * -0.1f;   
+        hydrophone4.position = hydrophone1.position + Vector3.up * -0.1f;   // Position unsure, change if incorrect
 
         roscon = ROSConnection.GetOrCreateInstance();
         roscon.RegisterPublisher<PingerTimeDifferenceMsg>(pingerTimeDifferenceTopicName); 

--- a/Assets/Scripts/PingerTimeDifference.cs
+++ b/Assets/Scripts/PingerTimeDifference.cs
@@ -117,10 +117,10 @@ public class PingerTimeDifference : MonoBehaviour {
         time4Diff[3] = time4[3] - time1[3];
         
 
-        timeDiffMsg.dt_pinger1 = new double[2] {time2Diff[0], time3Diff[0], time4Diff[0]};
-        timeDiffMsg.dt_pinger2 = new double[2] {time2Diff[1], time3Diff[1], time4Diff[1]};
-        timeDiffMsg.dt_pinger3 = new double[2] {time2Diff[2], time3Diff[2], time4Diff[2]};
-        timeDiffMsg.dt_pinger4 = new double[2] {time2Diff[3], time3Diff[3], time4Diff[3]};
+        timeDiffMsg.dt_pinger1 = new double[3] {time2Diff[0], time3Diff[0], time4Diff[0]};
+        timeDiffMsg.dt_pinger2 = new double[3] {time2Diff[1], time3Diff[1], time4Diff[1]};
+        timeDiffMsg.dt_pinger3 = new double[3] {time2Diff[2], time3Diff[2], time4Diff[2]};
+        timeDiffMsg.dt_pinger4 = new double[3] {time2Diff[3], time3Diff[3], time4Diff[3]};
 
         roscon.Publish(pingerTimeDifferenceTopicName, timeDiffMsg);
     }

--- a/Assets/Scripts/PingerTimeDifference.cs
+++ b/Assets/Scripts/PingerTimeDifference.cs
@@ -16,6 +16,7 @@ public class PingerTimeDifference : MonoBehaviour {
     public Transform hydrophone1;
     public Transform hydrophone2;
     public Transform hydrophone3;
+    public Transform hydrophone4;
     public Transform pinger1;
     public Transform pinger2;
     public Transform pinger3;
@@ -29,17 +30,21 @@ public class PingerTimeDifference : MonoBehaviour {
     double[] d1 = new double[4];
     double[] d2 = new double[4];
     double[] d3 = new double[4];
+    double[] d4 = new double[4];    // for fourth hydrophone
 
     double[] time1 = new double[4];
     double[] time2 = new double[4];
     double[] time3 = new double[4];
+    double[] time4 = new double[4]; 
     double[] time2Diff = new double[4];
     double[] time3Diff = new double[4];
+    double[] time4Diff = new double[4]; 
 
     void Start() {
         hydrophone1.position = transform.position + Vector3.up * -0.5f;
         hydrophone2.position = hydrophone1.position + Vector3.forward * 0.1f;
         hydrophone3.position = hydrophone1.position + Vector3.right * -0.1f;
+        hydrophone4.position = hydrophone1.position + Vector3.up * -0.1f;   
 
         roscon = ROSConnection.GetOrCreateInstance();
         roscon.RegisterPublisher<PingerTimeDifferenceMsg>(pingerTimeDifferenceTopicName); 
@@ -55,55 +60,67 @@ public class PingerTimeDifference : MonoBehaviour {
         d1[0] = Vector3.Distance(hydrophone1.position, pinger1.position);
         d2[0] = Vector3.Distance(hydrophone2.position, pinger1.position);
         d3[0] = Vector3.Distance(hydrophone3.position, pinger1.position);
+        d4[0] = Vector3.Distance(hydrophone4.position, pinger1.position);
 
         time1[0] = d1[0] / speedOfSound;
         time2[0] = d2[0] / speedOfSound;
         time3[0] = d3[0] / speedOfSound;
+        time4[0] = d4[0] / speedOfSound;
 
         time2Diff[0] = time2[0] - time1[0];
         time3Diff[0] = time3[0] - time1[0];
+        time4Diff[0] = time4[0] - time1[0];
 
         // Pinger 2
         d1[1] = Vector3.Distance(hydrophone1.position, pinger2.position);
         d2[1] = Vector3.Distance(hydrophone2.position, pinger2.position);
         d3[1] = Vector3.Distance(hydrophone3.position, pinger2.position);
+        d4[1] = Vector3.Distance(hydrophone4.position, pinger2.position);
 
         time1[1] = d1[1] / speedOfSound;
         time2[1] = d2[1] / speedOfSound;
         time3[1] = d3[1] / speedOfSound;
+        time4[1] = d4[1] / speedOfSound;
 
         time2Diff[1] = time2[1] - time1[1];
         time3Diff[1] = time3[1] - time1[1];
+        time4Diff[1] = time4[1] - time1[1];
 
         // Pinger 3
         d1[2] = Vector3.Distance(hydrophone1.position, pinger3.position);
         d2[2] = Vector3.Distance(hydrophone2.position, pinger3.position);
         d3[2] = Vector3.Distance(hydrophone3.position, pinger3.position);
+        d4[2] = Vector3.Distance(hydrophone4.position, pinger3.position);
 
         time1[2] = d1[2] / speedOfSound;
         time2[2] = d2[2] / speedOfSound;
         time3[2] = d3[2] / speedOfSound;
+        time4[2] = d4[2] / speedOfSound;
 
         time2Diff[2] = time2[2] - time1[2];
         time3Diff[2] = time3[2] - time1[2];
+        time4Diff[2] = time4[2] - time1[2];
 
         // Pinger 4
         d1[3] = Vector3.Distance(hydrophone1.position, pinger4.position);
         d2[3] = Vector3.Distance(hydrophone2.position, pinger4.position);
         d3[3] = Vector3.Distance(hydrophone3.position, pinger4.position);
+        d4[3] = Vector3.Distance(hydrophone4.position, pinger4.position);
 
         time1[3] = d1[3] / speedOfSound;
         time2[3] = d2[3] / speedOfSound;
         time3[3] = d3[3] / speedOfSound;
+        time4[3] = d4[3] / speedOfSound;
 
         time2Diff[3] = time2[3] - time1[3];
         time3Diff[3] = time3[3] - time1[3];
+        time4Diff[3] = time4[3] - time1[3];
         
 
-        timeDiffMsg.dt_pinger1 = new double[2] {time2Diff[0], time3Diff[0]};
-        timeDiffMsg.dt_pinger2 = new double[2] {time2Diff[1], time3Diff[1]};
-        timeDiffMsg.dt_pinger3 = new double[2] {time2Diff[2], time3Diff[2]};
-        timeDiffMsg.dt_pinger4 = new double[2] {time2Diff[3], time3Diff[3]};
+        timeDiffMsg.dt_pinger1 = new double[2] {time2Diff[0], time3Diff[0], time4Diff[0]};
+        timeDiffMsg.dt_pinger2 = new double[2] {time2Diff[1], time3Diff[1], time4Diff[1]};
+        timeDiffMsg.dt_pinger3 = new double[2] {time2Diff[2], time3Diff[2], time4Diff[2]};
+        timeDiffMsg.dt_pinger4 = new double[2] {time2Diff[3], time3Diff[3], time4Diff[3]};
 
         roscon.Publish(pingerTimeDifferenceTopicName, timeDiffMsg);
     }

--- a/ProjectSettings/ProjectSettings.asset
+++ b/ProjectSettings/ProjectSettings.asset
@@ -908,7 +908,13 @@ PlayerSettings:
   XboxOneOverrideIdentityName: 
   XboxOneOverrideIdentityPublisher: 
   vrEditorSettings: {}
-  cloudServicesEnabled: {}
+  cloudServicesEnabled:
+    Build: 0
+    Game Performance: 0
+    Legacy Analytics: 0
+    Purchasing: 0
+    UDP: 0
+    Unity Ads: 0
   luminIcon:
     m_Name: 
     m_ModelFolderPath: 
@@ -928,11 +934,11 @@ PlayerSettings:
   apiCompatibilityLevel: 6
   activeInputHandler: 0
   windowsGamepadBackendHint: 0
-  cloudProjectId: 6cd96846-49f4-41d2-9d2a-2bd5cc8d24a6
+  cloudProjectId: 3e378c8b-94db-4829-b0f0-a2ade5789667
   framebufferDepthMemorylessMode: 0
   qualitySettingsNames: []
-  projectName: auv-sim-unity-HDRP
-  organizationId: averystraumann
+  projectName: AUV-SIM-UNITY
+  organizationId: unity_a6ddaa592a0d2d6d09c9
   cloudEnabled: 0
   legacyClampBlendShapeWeights: 0
   hmiLoadingImage: {fileID: 0}

--- a/auv-sim-unity.sln
+++ b/auv-sim-unity.sln
@@ -1,19 +1,24 @@
 ﻿
-Microsoft Visual Studio Solution File, Format Version 11.00
-# Visual Studio 2010
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Assembly-CSharp", "Assembly-CSharp.csproj", "{420cbcb8-2d13-6eb9-1beb-24d694cb5d76}"
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 15
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Assembly-CSharp", "Assembly-CSharp.csproj", "{B8BC0C42-132D-B96E-1BEB-24D694CB5D76}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Assembly-CSharp-Editor", "Assembly-CSharp-Editor.csproj", "{913bfbf6-914b-276d-c214-33d06e807f38}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Assembly-CSharp-Editor", "Assembly-CSharp-Editor.csproj", "{F6FB3B91-4B91-6D27-C214-33D06E807F38}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{420cbcb8-2d13-6eb9-1beb-24d694cb5d76}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{420cbcb8-2d13-6eb9-1beb-24d694cb5d76}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{913bfbf6-914b-276d-c214-33d06e807f38}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{913bfbf6-914b-276d-c214-33d06e807f38}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B8BC0C42-132D-B96E-1BEB-24D694CB5D76}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B8BC0C42-132D-B96E-1BEB-24D694CB5D76}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B8BC0C42-132D-B96E-1BEB-24D694CB5D76}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{B8BC0C42-132D-B96E-1BEB-24D694CB5D76}.Release|Any CPU.Build.0 = Release|Any CPU
+		{F6FB3B91-4B91-6D27-C214-33D06E807F38}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{F6FB3B91-4B91-6D27-C214-33D06E807F38}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{F6FB3B91-4B91-6D27-C214-33D06E807F38}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{F6FB3B91-4B91-6D27-C214-33D06E807F38}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
## Related Issue(s)
  - [Add 4th hydrophone support](https://github.com/mcgill-robotics/AUV-2024/issues/522)

## Other Dependent PRs
  - [PR #550 from AUV-2024](https://github.com/mcgill-robotics/AUV-2024/pull/550)

## Changes Made
- Added calculations for the time difference between hydrophone O (base) and hydrophoneZ (the newly added fourth hydrophone)
- Renamed hydrophones 1-4 to O, X, Y, Z

## Rationale/Other Solutions Considered
- There is the potential for a new hydrophone to be added in future competitions.

## Tests Done
- Refer to Issue 522 from AUV-2024
