### PR TITLE
Fix: Diana Belief Rotation Angles from Radian to Euler

### DIFF
--- a/Assets/Scripts/VisualizeAUVBeliefs.cs
+++ b/Assets/Scripts/VisualizeAUVBeliefs.cs
@@ -82,7 +82,11 @@ public class VisualizeAUVBeliefs : MonoBehaviour
 	private void Update()
 	{
 		dianaVisualization.transform.position = currentAUVPos;
-		dianaVisualization.transform.rotation = Quaternion.Euler(currentAUVRot.x, currentAUVRot.y, currentAUVRot.z) * Quaternion.Euler(0, -90, 0);
+		dianaVisualization.transform.rotation = Quaternion.Euler(
+			currentAUVRot.x * Mathf.Rad2Deg, 
+			currentAUVRot.y * Mathf.Rad2Deg, 
+			currentAUVRot.z * Mathf.Rad2Deg
+		) * Quaternion.Euler(0f, -90f, 0f);	// use efloating point
 	}
 	
 	private void OnDestroy()


### PR DESCRIPTION
## Issue

AUV's "shadow" belief would not rotate properly because it was using radians to update.

## Fix

Added conversion to euler degrees.

## Tests Done

Tested using missions and moving around, flipping crazily.
 